### PR TITLE
Fix usage of path module for older node.js versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var plugins = {
     typings: require("typings")
 };
 var forEach = function (file, enc, cb) {
-    plugins.typings.install({ production: false, cwd: plugins.path.parse(file.path).dir })
+    plugins.typings.install({ production: false, cwd: plugins.path.dirname(file.path) })
         .then(function () {
         cb(null, file);
     }, function () {

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -7,7 +7,7 @@ var plugins = {
 };
 
 var forEach = function(file,enc,cb){
-    plugins.typings.install({production: false, cwd: plugins.path.parse(file.path).dir})
+    plugins.typings.install({production: false, cwd: plugins.path.dirname(file.path)})
         .then(function(){
             cb(null,file);
         },function(){


### PR DESCRIPTION
`path.parse` does not exist in older Node.js versions but for this use case `path.dirname` can be used instead.